### PR TITLE
[vuln] upgrade rimraf to 5.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   "dependencies": {
     "flatted": "^3.2.9",
     "keyv": "^4.5.3",
-    "rimraf": "^3.0.2"
+    "rimraf": "^5.0.5"
   }
 }


### PR DESCRIPTION
```
@org/package@0.0.0-use.local
 `- eslint@8.54.0
    `- file-entry-cache@6.0.1
        `- flat-cache@3.2.0
            `- rimraf@3.0.2 *1
                `- glob@7.2.3 *1
                    `-inflight@1.0.6 *2
```

*1: Old `glob` used to depend on `inflight`, but no longer does.
*2: https://github.com/isaacs/inflight/issues/5
