### PR TITLE
refactor: prefer let/const over var

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ npm i --save flat-cache
 ## Usage
 
 ```js
-var flatCache = require('flat-cache');
+const flatCache = require('flat-cache');
 // loads the cache, if one does not exists for the given
 // Id a new one will be prepared to be created
-var cache = flatCache.load('cacheId');
+const cache = flatCache.load('cacheId');
 
 // sets a key on the cache
 cache.setKey('key', { foo: 'var' });
@@ -39,7 +39,7 @@ cache.save(); // very important, if you don't save no changes will be persisted.
 
 // loads the cache from a given directory, if one does
 // not exists for the given Id a new one will be prepared to be created
-var cache = flatCache.load('cacheId', path.resolve('./path/to/folder'));
+const cache = flatCache.load('cacheId', path.resolve('./path/to/folder'));
 
 // The following methods are useful to clear the cache
 // delete a given cache

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,9 +1,8 @@
 const path = require('path');
 const fs = require('fs');
 const Keyv = require('keyv');
-const utils = require('./utils');
-const del = require('./del');
-const writeJSON = utils.writeJSON;
+const { writeJSON, tryParse } = require('./utils');
+const { del } = require('./del');
 
 const cache = {
   /**
@@ -25,7 +24,7 @@ const cache = {
     me._pathToFile = cacheDir ? path.resolve(cacheDir, docId) : path.resolve(__dirname, '../.cache/', docId);
 
     if (fs.existsSync(me._pathToFile)) {
-      me._persisted = utils.tryParse(me._pathToFile, {});
+      me._persisted = tryParse(me._pathToFile, {});
     }
   },
 

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,11 +1,11 @@
-var path = require('path');
-var fs = require('fs');
-var Keyv = require('keyv');
-var utils = require('./utils');
-var del = require('./del');
-var writeJSON = utils.writeJSON;
+const path = require('path');
+const fs = require('fs');
+const Keyv = require('keyv');
+const utils = require('./utils');
+const del = require('./del');
+const writeJSON = utils.writeJSON;
 
-var cache = {
+const cache = {
   /**
    * Load a cache identified by the given Id. If the element does not exists, then initialize an empty
    * cache storage. If specified `cacheDir` will be used as the directory to persist the data to. If omitted
@@ -16,12 +16,12 @@ var cache = {
    * @param [cacheDir] {String} directory for the cache entry
    */
   load: function (docId, cacheDir) {
-    var me = this;
-
+    const me = this;
     me.keyv = new Keyv();
 
     me.__visited = {};
     me.__persisted = {};
+
     me._pathToFile = cacheDir ? path.resolve(cacheDir, docId) : path.resolve(__dirname, '../.cache/', docId);
 
     if (fs.existsSync(me._pathToFile)) {
@@ -53,9 +53,9 @@ var cache = {
    * @param  {String} pathToFile the path to the file containing the info for the cache
    */
   loadFile: function (pathToFile) {
-    var me = this;
-    var dir = path.dirname(pathToFile);
-    var fName = path.basename(pathToFile);
+    const me = this;
+    const dir = path.dirname(pathToFile);
+    const fName = path.basename(pathToFile);
 
     me.load(fName, dir);
   },
@@ -109,10 +109,10 @@ var cache = {
    * @private
    */
   _prune: function () {
-    var me = this;
-    var obj = {};
+    const me = this;
+    const obj = {};
 
-    var keys = Object.keys(me._visited);
+    const keys = Object.keys(me._visited);
 
     // no keys visited for either get or set value
     if (keys.length === 0) {
@@ -134,8 +134,7 @@ var cache = {
    * @method save
    */
   save: function (noPrune) {
-    var me = this;
-
+    const me = this;
     !noPrune && me._prune();
     writeJSON(me._pathToFile, me._persisted);
   },
@@ -153,7 +152,7 @@ var cache = {
    * @method destroy
    */
   destroy: function () {
-    var me = this;
+    const me = this;
     me._visited = {};
     me._persisted = {};
 
@@ -184,13 +183,13 @@ module.exports = {
    * @returns {cache} cache instance
    */
   create: function (docId, cacheDir) {
-    var obj = Object.create(cache);
+    const obj = Object.create(cache);
     obj.load(docId, cacheDir);
     return obj;
   },
 
   createFromFile: function (filePath) {
-    var obj = Object.create(cache);
+    const obj = Object.create(cache);
     obj.loadFile(filePath);
     return obj;
   },
@@ -203,7 +202,7 @@ module.exports = {
    * @returns {Boolean} true if the cache folder was deleted. False otherwise
    */
   clearCacheById: function (docId, cacheDir) {
-    var filePath = cacheDir ? path.resolve(cacheDir, docId) : path.resolve(__dirname, '../.cache/', docId);
+    const filePath = cacheDir ? path.resolve(cacheDir, docId) : path.resolve(__dirname, '../.cache/', docId);
     return del(filePath);
   },
   /**
@@ -212,7 +211,7 @@ module.exports = {
    * @returns {Boolean} true if the cache folder was deleted. False otherwise
    */
   clearAll: function (cacheDir) {
-    var filePath = cacheDir ? path.resolve(cacheDir) : path.resolve(__dirname, '../.cache/');
+    const filePath = cacheDir ? path.resolve(cacheDir) : path.resolve(__dirname, '../.cache/');
     return del(filePath);
   },
 };

--- a/src/del.js
+++ b/src/del.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-module.exports = function del(targetPath) {
+function del(targetPath) {
   if (!fs.existsSync(targetPath)) {
     return false;
   }
@@ -25,4 +25,6 @@ module.exports = function del(targetPath) {
   } catch (error) {
     console.error(`Error while deleting ${targetPath}: ${error.message}`);
   }
-};
+}
+
+module.exports = { del };

--- a/src/del.js
+++ b/src/del.js
@@ -1,5 +1,5 @@
-var fs = require('fs');
-var path = require('path');
+const fs = require('fs');
+const path = require('path');
 
 module.exports = function del(targetPath) {
   if (!fs.existsSync(targetPath)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,10 @@
-var fs = require('fs');
-var path = require('path');
-var flatted = require('flatted');
+const fs = require('fs');
+const path = require('path');
+const flatted = require('flatted');
 
 module.exports = {
   tryParse: function (filePath, defaultValue) {
-    var result;
+    let result;
     try {
       result = this.readJSON(filePath);
     } catch (ex) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,43 +2,41 @@ const fs = require('fs');
 const path = require('path');
 const flatted = require('flatted');
 
-module.exports = {
-  tryParse: function (filePath, defaultValue) {
-    let result;
-    try {
-      result = this.readJSON(filePath);
-    } catch (ex) {
-      result = defaultValue;
-    }
-    return result;
-  },
+function tryParse(filePath, defaultValue) {
+  let result;
+  try {
+    result = readJSON(filePath);
+  } catch (ex) {
+    result = defaultValue;
+  }
+  return result;
+}
 
-  /**
-   * Read json file synchronously using flatted
-   *
-   * @method readJSON
-   * @param  {String} filePath Json filepath
-   * @returns {*} parse result
-   */
-  readJSON: function (filePath) {
-    return flatted.parse(
-      fs.readFileSync(filePath, {
-        encoding: 'utf8',
-      })
-    );
-  },
+/**
+ * Read json file synchronously using flatted
+ *
+ * @param  {String} filePath Json filepath
+ * @returns {*} parse result
+ */
+function readJSON(filePath) {
+  return flatted.parse(
+    fs.readFileSync(filePath, {
+      encoding: 'utf8',
+    })
+  );
+}
 
-  /**
-   * Write json file synchronously using circular-json
-   *
-   * @method writeJSON
-   * @param  {String} filePath Json filepath
-   * @param  {*} data Object to serialize
-   */
-  writeJSON: function (filePath, data) {
-    fs.mkdirSync(path.dirname(filePath), {
-      recursive: true,
-    });
-    fs.writeFileSync(filePath, flatted.stringify(data));
-  },
-};
+/**
+ * Write json file synchronously using circular-json
+ *
+ * @param  {String} filePath Json filepath
+ * @param  {*} data Object to serialize
+ */
+function writeJSON(filePath, data) {
+  fs.mkdirSync(path.dirname(filePath), {
+    recursive: true,
+  });
+  fs.writeFileSync(filePath, flatted.stringify(data));
+}
+
+module.exports = { tryParse, readJSON, writeJSON };

--- a/test/runner.js
+++ b/test/runner.js
@@ -34,7 +34,7 @@ expand('test/specs/**/*.js').forEach(function (file) {
 });
 
 m.run(function (err) {
-  var exitCode = err ? 1 : 0;
+  const exitCode = err ? 1 : 0;
   if (err) console.log('failed tests: ' + err);
   process.exit(exitCode);
 });

--- a/test/runner.js
+++ b/test/runner.js
@@ -3,13 +3,13 @@
 // we run mocha manually otherwise istanbul coverage won't work
 // run `npm test --coverage` to generate coverage report
 
-var Mocha = require('mocha');
+const Mocha = require('mocha');
 
 // ---
 
 // to set these options run the test script like:
 //  > BAIL=true GREP=array_expression REPORTER=dot npm test
-var opts = {
+const opts = {
   ui: 'bdd',
   bail: !!process.env.BAIL,
   reporter: process.env.REPORTER || 'spec',
@@ -22,13 +22,13 @@ if (process.env.TRAVIS) {
   opts.reporter = 'dot';
 }
 
-var m = new Mocha(opts);
+const m = new Mocha(opts);
 
 if (process.env.INVERT) {
   m.invert();
 }
 
-var expand = require('glob-expand');
+const expand = require('glob-expand');
 expand('test/specs/**/*.js').forEach(function (file) {
   m.addFile(file);
 });

--- a/test/specs/cache.js
+++ b/test/specs/cache.js
@@ -1,12 +1,12 @@
-var expect = require('chai').expect;
-var readJSON = require('../../src/utils').readJSON;
-var path = require('path');
-var rimraf = require('rimraf').sync;
-var fs = require('fs');
-var flatCache = require('../../src/cache');
-var write = require('write');
-var del = require('../../src/del');
-var sinon = require('sinon');
+const { expect } = require('chai');
+const { readJSON } = require('../../src/utils');
+const path = require('path');
+const { sync: rimraf } = require('rimraf');
+const fs = require('fs');
+const flatCache = require('../../src/cache');
+const write = require('write');
+const { del } = require('../../src/del');
+const sinon = require('sinon');
 
 describe('flat-cache', function () {
   beforeEach(function () {

--- a/test/specs/cache.js
+++ b/test/specs/cache.js
@@ -22,33 +22,33 @@ describe('flat-cache', function () {
   });
 
   it('should not crash if the cache file exists but it is an empty string', function () {
-    var cachePath = path.resolve(__dirname, '../fixtures/.cache2');
+    const cachePath = path.resolve(__dirname, '../fixtures/.cache2');
     write.sync(path.join(cachePath, 'someId'), '');
 
     expect(function () {
-      var cache = flatCache.load('someId', cachePath);
+      const cache = flatCache.load('someId', cachePath);
       expect(cache._persisted).to.deep.equal({});
     }).to.not.throw(Error);
   });
 
   it('should not crash if the cache file exists but it is an invalid JSON string', function () {
-    var cachePath = path.resolve(__dirname, '../fixtures/.cache2');
+    const cachePath = path.resolve(__dirname, '../fixtures/.cache2');
     write.sync(path.join(cachePath, 'someId'), '{ "foo": "fookey", "bar" ');
 
     expect(function () {
-      var cache = flatCache.load('someId', cachePath);
+      const cache = flatCache.load('someId', cachePath);
       expect(cache._persisted).to.deep.equal({});
     }).to.not.throw(Error);
   });
 
   it('should create a cache object if none existed in disc with the given id', function () {
-    var cache = flatCache.load('someId');
+    const cache = flatCache.load('someId');
     expect(cache.keys().length).to.equal(0);
   });
 
   it('should set a key and persist it', function () {
-    var cache = flatCache.load('someId');
-    var data = {
+    const cache = flatCache.load('someId');
+    const data = {
       foo: 'foo',
       bar: 'bar',
     };
@@ -61,8 +61,8 @@ describe('flat-cache', function () {
   });
 
   it('should remove a key from the cache object and persist the change', function () {
-    var cache = flatCache.load('someId');
-    var data = {
+    const cache = flatCache.load('someId');
+    const data = {
       foo: 'foo',
       bar: 'bar',
     };
@@ -83,7 +83,7 @@ describe('flat-cache', function () {
 
   describe('loading an existing cache', function () {
     beforeEach(function () {
-      var cache = flatCache.load('someId');
+      const cache = flatCache.load('someId');
       cache.setKey('foo', {
         bar: 'baz',
       });
@@ -94,19 +94,19 @@ describe('flat-cache', function () {
     });
 
     it('should load an existing cache', function () {
-      var cache = flatCache.load('someId');
+      const cache = flatCache.load('someId');
       expect(readJSON(path.resolve(__dirname, '../../.cache/someId'))).to.deep.equal(cache._persisted);
     });
 
     it('should return the same structure if load called twice with the same docId', function () {
-      var cache = flatCache.load('someId');
-      var cache2 = flatCache.load('someId');
+      const cache = flatCache.load('someId');
+      const cache2 = flatCache.load('someId');
 
       expect(cache._persisted).to.deep.equal(cache2._persisted);
     });
 
     it('should remove the key and persist the new state', function () {
-      var cache = flatCache.load('someId');
+      const cache = flatCache.load('someId');
       cache.removeKey('foo');
       cache.save();
       expect(readJSON(path.resolve(__dirname, '../../.cache/someId'))).to.deep.equal({
@@ -117,12 +117,12 @@ describe('flat-cache', function () {
     });
 
     it('should clear the cache identified by the given id', function () {
-      var cache = flatCache.load('someId');
+      const cache = flatCache.load('someId');
       cache.save();
-      var exists = fs.existsSync(path.resolve(__dirname, '../../.cache/someId'));
+      let exists = fs.existsSync(path.resolve(__dirname, '../../.cache/someId'));
       expect(exists).to.be.true;
 
-      var deleted = flatCache.clearCacheById('someId');
+      let deleted = flatCache.clearCacheById('someId');
       exists = fs.existsSync(path.resolve(__dirname, '../../.cache/someId'));
       expect(deleted).to.be.true;
       expect(exists).to.be.false;
@@ -134,7 +134,7 @@ describe('flat-cache', function () {
 
   describe('loading an existing cache custom directory', function () {
     beforeEach(function () {
-      var cache = flatCache.load('someId', path.resolve(__dirname, '../fixtures/.cache2'));
+      const cache = flatCache.load('someId', path.resolve(__dirname, '../fixtures/.cache2'));
       cache.setKey('foo', {
         bar: 'baz',
       });
@@ -145,19 +145,19 @@ describe('flat-cache', function () {
     });
 
     it('should load an existing cache', function () {
-      var cache = flatCache.load('someId', path.resolve(__dirname, '../fixtures/.cache2'));
+      const cache = flatCache.load('someId', path.resolve(__dirname, '../fixtures/.cache2'));
       expect(readJSON(path.resolve(__dirname, '../fixtures/.cache2/someId'))).to.deep.equal(cache._persisted);
     });
 
     it('should return the same structure if load called twice with the same docId', function () {
-      var cache = flatCache.load('someId', path.resolve(__dirname, '../fixtures/.cache2'));
-      var cache2 = flatCache.load('someId', path.resolve(__dirname, '../fixtures/.cache2'));
+      const cache = flatCache.load('someId', path.resolve(__dirname, '../fixtures/.cache2'));
+      const cache2 = flatCache.load('someId', path.resolve(__dirname, '../fixtures/.cache2'));
 
       expect(cache._persisted).to.deep.equal(cache2._persisted);
     });
 
     it('should remove the cache file from disk using flatCache.clearCacheById', function () {
-      var cache = flatCache.load('someId', path.resolve(__dirname, '../fixtures/.cache2'));
+      const cache = flatCache.load('someId', path.resolve(__dirname, '../fixtures/.cache2'));
       cache.save();
       expect(fs.existsSync(path.resolve(__dirname, '../fixtures/.cache2/someId'))).to.be.true;
       flatCache.clearCacheById('someId', path.resolve(__dirname, '../fixtures/.cache2'));
@@ -165,7 +165,7 @@ describe('flat-cache', function () {
     });
 
     it('should remove the cache file from disk using removeCacheFile', function () {
-      var cache = flatCache.load('someId', path.resolve(__dirname, '../fixtures/.cache2'));
+      const cache = flatCache.load('someId', path.resolve(__dirname, '../fixtures/.cache2'));
       cache.save();
       expect(fs.existsSync(path.resolve(__dirname, '../fixtures/.cache2/someId'))).to.be.true;
       cache.removeCacheFile();
@@ -196,7 +196,7 @@ describe('flat-cache', function () {
       const error = new Error('Fake error');
       sandbox.stub(fs, 'unlinkSync').throws(error);
 
-      var consoleLog = console.error;
+      const consoleLog = console.error;
       console.error = function () {};
 
       try {
@@ -210,14 +210,14 @@ describe('flat-cache', function () {
   });
 
   describe('loading a cache using a filePath directly', function () {
-    var file;
+    let file;
     beforeEach(function () {
       file = path.resolve(__dirname, '../fixtures/.cache2/mycache-file.cache');
       rimraf(file);
     });
 
     it('should create the file if it does not exists before', function () {
-      var cache = flatCache.createFromFile(file);
+      const cache = flatCache.createFromFile(file);
       cache.setKey('foo', {
         bar: 'baz',
       });
@@ -231,7 +231,7 @@ describe('flat-cache', function () {
     });
 
     it('should delete the cache file using removeCacheFile', function () {
-      var cache = flatCache.createFromFile(file);
+      const cache = flatCache.createFromFile(file);
       cache.setKey('foo', {
         bar: 'baz',
       });
@@ -252,7 +252,7 @@ describe('flat-cache', function () {
     });
 
     it('should delete the cache file using destroy', function () {
-      var cache = flatCache.createFromFile(file);
+      const cache = flatCache.createFromFile(file);
       cache.setKey('foo', {
         bar: 'baz',
       });
@@ -273,7 +273,7 @@ describe('flat-cache', function () {
     it('should remove non "visited" entries', function () {
       // a visited entry is one that was either queried
       // using getKey or updated with setKey
-      var cache = flatCache.createFromFile(file);
+      let cache = flatCache.createFromFile(file);
 
       cache.setKey('foo', {
         bar: 'baz',
@@ -284,7 +284,7 @@ describe('flat-cache', function () {
 
       cache.save();
 
-      var expectedResult = {
+      let expectedResult = {
         bar: {
           foo: 'baz',
         },
@@ -300,7 +300,7 @@ describe('flat-cache', function () {
       cache = flatCache.createFromFile(file);
 
       // we query one key (visit)
-      var res = cache.getKey('foo');
+      const res = cache.getKey('foo');
 
       // then we check the value is what we stored
       expect(res).to.deep.equal({
@@ -321,7 +321,7 @@ describe('flat-cache', function () {
     it('should keep non "visited" entries if noProne is set to true', function () {
       // a visited entry is one that was either queried
       // using getKey or updated with setKey
-      var cache = flatCache.createFromFile(file);
+      let cache = flatCache.createFromFile(file);
 
       cache.setKey('foo', {
         bar: 'baz',
@@ -334,7 +334,7 @@ describe('flat-cache', function () {
       // because all keys were visited
       cache.save();
 
-      var expectedResult = {
+      const expectedResult = {
         bar: {
           foo: 'baz',
         },
@@ -350,7 +350,7 @@ describe('flat-cache', function () {
       cache = flatCache.createFromFile(file);
 
       // we query one key (visit)
-      var res = cache.getKey('foo');
+      const res = cache.getKey('foo');
 
       // then we check the value is what we stored
       expect(res).to.deep.equal({
@@ -364,8 +364,8 @@ describe('flat-cache', function () {
   });
 
   it('should serialize and deserialize properly circular reference', function () {
-    var cache = flatCache.load('someId');
-    var data = {
+    const cache = flatCache.load('someId');
+    const data = {
       foo: 'foo',
       bar: 'bar',
     };
@@ -380,8 +380,8 @@ describe('flat-cache', function () {
   });
 
   it('should return the entire persisted object', function () {
-    var cache = flatCache.load('someId');
-    var data = {
+    const cache = flatCache.load('someId');
+    const data = {
       foo: 'foo',
       bar: true,
       x: ['0', '1'],
@@ -389,7 +389,7 @@ describe('flat-cache', function () {
 
     cache.setKey('some-key', data);
 
-    var data2 = {
+    const data2 = {
       key: 9,
       z: {
         x: [true, false],
@@ -398,7 +398,7 @@ describe('flat-cache', function () {
 
     cache.setKey('some-second-key', data2);
 
-    var data3 = true;
+    const data3 = true;
 
     cache.setKey('some-third-key', data3);
 


### PR DESCRIPTION
This PR switches to using the `let` and `const` keywords instead of `var` in the source code, as is the standard nowadays.